### PR TITLE
Adapt the banner to mobile screens

### DIFF
--- a/mobile/mobile.scss
+++ b/mobile/mobile.scss
@@ -1,0 +1,18 @@
+.below-site-header-outlet.welcome-link-banner-connector {
+    .welcome-link-banner-wrapper {
+        background-image: url(#{$mobile-banner-background-image});
+        .welcome-wrapper {
+            .featured-banner-link {
+                flex-direction: row;
+                padding-bottom: 1.5em;
+                &>div a {
+                    padding: 0 5px;
+                    h3 {
+                        font-size: 0.75em;
+                        white-space: normal;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/settings.yml
+++ b/settings.yml
@@ -34,6 +34,10 @@ banner_background_image:
   type: upload
   default: ""
 
+mobile_banner_background_image:
+  type: upload
+  default: ""
+
 banner_background_repeat:
   type: enum
   default: no-repeat


### PR DESCRIPTION
These are the style changes suggested by Kuro282 in https://meta.discourse.org/t/welcome-link-banner/218743/41.

@kuro282 removed the locale changes as requested in https://github.com/discourse/discourse-welcome-link-banner/pull/5#issuecomment-1216643843, but I think it needs a fresh PR (hence this one)