### PR TITLE
UX: obey user setting for external link behavior

### DIFF
--- a/javascripts/discourse/helpers/is-external-link.js
+++ b/javascripts/discourse/helpers/is-external-link.js
@@ -1,0 +1,12 @@
+import { helper } from "@ember/component/helper";
+
+export default helper(function isExternalLink([url], _hash) {
+  const currentUser = _hash.currentUser;
+  const link = new URL(url, window.location);
+
+  if (!currentUser?.user_option.external_links_in_new_tab) {
+    return;
+  }
+
+  return link.hostname !== window.location.hostname;
+});

--- a/javascripts/discourse/templates/components/welcome-link-banner.hbs
+++ b/javascripts/discourse/templates/components/welcome-link-banner.hbs
@@ -1,4 +1,3 @@
-
 {{#unless hideStaff}}
   {{#unless (and (theme-setting 'hide_on_mobile') site.mobileView)}}
     {{#if (and showTrust showHere)}}
@@ -12,7 +11,7 @@
             <div class="featured-banner-link">
               {{#each bannerLinks as |bl|}}
                 <div>
-                  <a href="{{bl.url}}">
+                  <a href="{{bl.url}}" target={{if (is-external-link bl.url currentUser=this.currentUser) '_blank'}}>
                     <h3>
                       {{d-icon bl.icon}}
                       {{bl.text}}
@@ -27,5 +26,3 @@
     {{/if}}
   {{/unless}}
 {{/unless}}
-
-


### PR DESCRIPTION
This adds a helper to handle the `external_links_in_new_tab` user setting, so external links will open in a new tab when called for. 